### PR TITLE
Improved resizing of small selections

### DIFF
--- a/src/xo-misc.h
+++ b/src/xo-misc.h
@@ -94,6 +94,12 @@ gboolean ok_to_close(void);
 
 void reset_focus(void);
 
+#define RESIZE_SIDE_TOP 1
+#define RESIZE_SIDE_BOTTOM 2
+#define RESIZE_SIDE_LEFT 4
+#define RESIZE_SIDE_RIGHT 8
+int get_resize_sides(double * pt);
+
 // selection / clipboard stuff
 
 void reset_selection(void);

--- a/src/xo-paint.c
+++ b/src/xo-paint.c
@@ -154,36 +154,28 @@ void update_cursor_for_resize(double *pt)
 {
   gboolean in_range_x, in_range_y;
   gboolean can_resize_left, can_resize_right, can_resize_bottom, can_resize_top;
-  gdouble resize_margin;
+  int resize_sides;
   GdkCursorType newcursor;
 
+  resize_sides = get_resize_sides(pt);
+  
   // if we're not even close to the box in some direction, return immediately
-  resize_margin = RESIZE_MARGIN / ui.zoom;
-  if (pt[0]<ui.selection->bbox.left-resize_margin || pt[0]>ui.selection->bbox.right+resize_margin
-   || pt[1]<ui.selection->bbox.top-resize_margin || pt[1]>ui.selection->bbox.bottom+resize_margin)
+  if (resize_sides == -1)
   {
     if (ui.is_sel_cursor) update_cursor();
     return;
   }
 
   ui.is_sel_cursor = TRUE;
-  can_resize_left = (pt[0] < ui.selection->bbox.left+resize_margin);
-  can_resize_right = (pt[0] > ui.selection->bbox.right-resize_margin);
-  can_resize_top = (pt[1] < ui.selection->bbox.top+resize_margin);
-  can_resize_bottom = (pt[1] > ui.selection->bbox.bottom-resize_margin);
 
-  if (can_resize_left) {
-    if (can_resize_top) newcursor = GDK_TOP_LEFT_CORNER;
-    else if (can_resize_bottom) newcursor = GDK_BOTTOM_LEFT_CORNER;
-    else newcursor = GDK_LEFT_SIDE;
-  }
-  else if (can_resize_right) {
-    if (can_resize_top) newcursor = GDK_TOP_RIGHT_CORNER;
-    else if (can_resize_bottom) newcursor = GDK_BOTTOM_RIGHT_CORNER;
-    else newcursor = GDK_RIGHT_SIDE;
-  }
-  else if (can_resize_top) newcursor = GDK_TOP_SIDE;
-  else if (can_resize_bottom) newcursor = GDK_BOTTOM_SIDE;
+  if (resize_sides == RESIZE_SIDE_TOP) newcursor = GDK_TOP_SIDE;
+  else if (resize_sides == RESIZE_SIDE_BOTTOM) newcursor = GDK_BOTTOM_SIDE;
+  else if (resize_sides == RESIZE_SIDE_LEFT) newcursor = GDK_LEFT_SIDE;
+  else if (resize_sides == RESIZE_SIDE_RIGHT) newcursor = GDK_RIGHT_SIDE;
+  else if (resize_sides == (RESIZE_SIDE_TOP | RESIZE_SIDE_LEFT)) newcursor = GDK_TOP_LEFT_CORNER;
+  else if (resize_sides == (RESIZE_SIDE_TOP | RESIZE_SIDE_RIGHT)) newcursor = GDK_TOP_RIGHT_CORNER;
+  else if (resize_sides == (RESIZE_SIDE_BOTTOM | RESIZE_SIDE_LEFT)) newcursor = GDK_BOTTOM_LEFT_CORNER;
+  else if (resize_sides == (RESIZE_SIDE_BOTTOM | RESIZE_SIDE_RIGHT)) newcursor = GDK_BOTTOM_RIGHT_CORNER;
   else newcursor = GDK_FLEUR;
 
   if (ui.cursor!=NULL && ui.cursor->type == newcursor) return;

--- a/src/xournal.h
+++ b/src/xournal.h
@@ -62,6 +62,7 @@
 #define DISPLAY_DPI_DEFAULT 96.0
 #define MIN_ZOOM 0.2
 #define RESIZE_MARGIN 6.0
+#define MOVE_MIN_INTERIOR 12.0
 #define MAX_SAFE_RENDER_DPI 720 // max dpi at which PDF bg's get rendered
 
 #define VBOX_MAIN_NITEMS 5 // number of interface items in vboxMain


### PR DESCRIPTION
When one selects something rather small (e.g. by clicking onto a small piece of text) and then wants to move it around, it easily happens that one accidentally resizes it. (At least this happens often to me on my high-resolution screen; it might not be a problem on lower resolutions.) This patch improves this: If the selection is small, the area where to click for resizing are shifted outwards, to enlarge the area in which to click for moving the selection.

Something like this actually was already implemented, but now the area is enlarged more than before. Moreover, the prev. version was slightly buggy: the mouse cursor didn't reflect the enlarged "move selection" area, whereas the new version does.

How it works:
- It's the function get_resize_sides() which decides what a click at a given point will do. (That function is also used to decide about the mouse cursor.)
- Usually, the resize area is 6px to both sides of the selection border (so 12px in total). This 12px stripe is moved outwards to ensure that the "move selection" area is at least 12px wide and high. However, the move selection area is never made bigger than the selection itself. (So really small selection might still be difficult to drag around.) Maybe one should also implement a minimal selection size, as suggested by Denis.
