### PR TITLE
Line widths and optimization

### DIFF
--- a/src/xo-clipboard.c
+++ b/src/xo-clipboard.c
@@ -100,7 +100,7 @@ void selection_to_clip(void)
             + sizeof(int) // num_points
             + 2*item->path->num_points*sizeof(double); // the points
       if (item->brush.variable_width)
-        bufsz += (item->path->num_points-1)*sizeof(double); // the widths
+        bufsz += (item->path->num_points)*sizeof(double); // the widths
     }
     else if (item->type == ITEM_TEXT) {
       bufsz+= sizeof(int) // type
@@ -148,8 +148,8 @@ void selection_to_clip(void)
       g_memmove(p, item->path->coords, 2*item->path->num_points*sizeof(double));
       p+= 2*item->path->num_points*sizeof(double);
       if (item->brush.variable_width) {
-        g_memmove(p, item->widths, (item->path->num_points-1)*sizeof(double));
-        p+= (item->path->num_points-1)*sizeof(double);
+        g_memmove(p, item->widths, (item->path->num_points)*sizeof(double));
+        p+= (item->path->num_points)*sizeof(double);
       }
     }
     if (item->type == ITEM_TEXT) {
@@ -258,8 +258,8 @@ void clipboard_paste_from_xournal(GtkSelectionData *sel_data)
       }
       p+= 2*item->path->num_points*sizeof(double);
       if (item->brush.variable_width) {
-        item->widths = g_memdup(p, (item->path->num_points-1)*sizeof(double));
-        p+= (item->path->num_points-1)*sizeof(double);
+        item->widths = g_memdup(p, (item->path->num_points)*sizeof(double));
+        p+= (item->path->num_points)*sizeof(double);
       }
       else item->widths = NULL;
       update_item_bbox(item);

--- a/src/xo-file.c
+++ b/src/xo-file.c
@@ -746,7 +746,6 @@ void xoj_parser_start_element(GMarkupParseContext *context,
           if (tmpItem->brush.variable_width) *error = xoj_invalid();
           tmpItem->brush.variable_width = TRUE;
           ui.cur_widths[0] = ui.cur_widths[1];
-          ui.cur_widths[i-1] = ui.cur_widths[i-2]; // last width seems to be invalid
           tmpItem->widths = (gdouble *) g_memdup(ui.cur_widths, i*sizeof(gdouble));
           ui.cur_path.num_points = i;
         }

--- a/src/xo-misc.c
+++ b/src/xo-misc.c
@@ -634,7 +634,7 @@ void make_canvas_stroke_disc(struct Item *item, double * pt, double * w)
      "fill-color-rgba", item->brush.color_rgba, NULL);
 }
 
-void make_canvas_stroke_segment(struct Item *item, double * pt, double * w)
+void make_canvas_stroke_trapeze(struct Item *item, double * pt, double * w)
 {
   GnomeCanvasPoints poly;
   double polypt[8];
@@ -646,7 +646,7 @@ void make_canvas_stroke_segment(struct Item *item, double * pt, double * w)
     polypt+0, polypt+1, polypt+2, polypt+3);
   gnome_canvas_get_butt_points(pt[2], pt[3], pt[0], pt[1], w[0], 0,
     polypt+4, polypt+5, polypt+6, polypt+7);
-  
+
   gnome_canvas_item_new((GnomeCanvasGroup *) item->canvas_item,
      gnome_canvas_polygon_get_type(), "points", &poly,
      "fill-color-rgba", item->brush.color_rgba, NULL);
@@ -709,7 +709,7 @@ void make_canvas_item_one(GnomeCanvasGroup *group, struct Item *item)
           if (!disc_done) {
             make_canvas_stroke_disc(item, item->path->coords+2*j0, item->widths+j0);
           }
-          make_canvas_stroke_segment(item, item->path->coords+2*j0, item->widths+j0);
+          make_canvas_stroke_trapeze(item, item->path->coords+2*j0, item->widths+j0);
           disc_done = FALSE; //CNTT++; // profiling...
           j0 = j;
         }

--- a/src/xo-misc.c
+++ b/src/xo-misc.c
@@ -653,7 +653,7 @@ void make_canvas_stroke_segment(struct Item *item, double * pt, double * w)
 
 }
 
-int CNTP, CNTS, CNTT;
+//int CNTP, CNTS, CNTT; // profiling...
 
 void make_canvas_item_one(GnomeCanvasGroup *group, struct Item *item)
 {
@@ -679,7 +679,7 @@ void make_canvas_item_one(GnomeCanvasGroup *group, struct Item *item)
       disc_done = FALSE;
       j0 = 0;
 
-      CNTP += item->path->num_points - 1;
+      //CNTP += item->path->num_points - 1; // profiling...
 
       while (j0 < item->path->num_points - 1) {
           
@@ -687,8 +687,8 @@ void make_canvas_item_one(GnomeCanvasGroup *group, struct Item *item)
         
         j = j0 + 1;
         while (j < item->path->num_points &&
-               item->widths[j] < wmin * 1.2 &&
-               item->widths[j] * 1.2 > wmax) {
+               item->widths[j] < wmin * LINE_WIDTH_PRECISION &&
+               item->widths[j] * LINE_WIDTH_PRECISION > wmax) {
           if (item->widths[j] < wmin) wmin = item->widths[j];
           if (item->widths[j] > wmax) wmax = item->widths[j];
           j++;
@@ -703,14 +703,14 @@ void make_canvas_item_one(GnomeCanvasGroup *group, struct Item *item)
               "cap-style", GDK_CAP_ROUND, "join-style", GDK_JOIN_ROUND, 
               "fill-color-rgba", item->brush.color_rgba,
               "width-units", (wmin + wmax) / 2, NULL);
-          disc_done = TRUE; CNTS++;
+          disc_done = TRUE; //CNTS++; // profiling...
           j0 = j - 1;
         } else { /* j == j0+1; draw trapeze from j0 to j */
           if (!disc_done) {
             make_canvas_stroke_disc(item, item->path->coords+2*j0, item->widths+j0);
           }
           make_canvas_stroke_segment(item, item->path->coords+2*j0, item->widths+j0);
-          disc_done = FALSE; CNTT++;
+          disc_done = FALSE; //CNTT++; // profiling...
           j0 = j;
         }
       }
@@ -765,9 +765,9 @@ void make_canvas_items(void)
   struct Item *item;
   GList *pagelist, *layerlist, *itemlist;
   
-  int ti; // profiling...
-  ti = clock(); // profiling...
-  CNTP=CNTS=CNTT=0; // profiling...
+  //int ti; // profiling...
+  //ti = clock(); // profiling...
+  //CNTP=CNTS=CNTT=0; // profiling...
   
   for (pagelist = journal.pages; pagelist!=NULL; pagelist = pagelist->next) {
     pg = (struct Page *)pagelist->data;
@@ -790,7 +790,7 @@ void make_canvas_items(void)
     }
   }
   
-  printf("Cnts: P=%d, S=%d, T=%d; Time: %d\n", CNTP, CNTS, CNTT, (int)(clock() - ti)); // profiling...
+  //printf("Cnts: P=%d, S=%d, T=%d; Time: %d\n", CNTP, CNTS, CNTT, (int)(clock() - ti)); // profiling...
 }
 
 void update_canvas_bg(struct Page *pg)

--- a/src/xo-misc.c
+++ b/src/xo-misc.c
@@ -625,6 +625,35 @@ void make_page_clipbox(struct Page *pg)
   gnome_canvas_path_def_unref(pg_clip);
 }
 
+void make_canvas_stroke_disc(struct Item *item, double * pt, double * w)
+{
+  gnome_canvas_item_new((GnomeCanvasGroup *) item->canvas_item,
+     gnome_canvas_ellipse_get_type(),
+     "x1", pt[0]-w[0]/2, "y1", pt[1]-w[0]/2,
+     "x2", pt[0]+w[0]/2, "y2", pt[1]+w[0]/2,
+     "fill-color-rgba", item->brush.color_rgba, NULL);
+}
+
+void make_canvas_stroke_segment(struct Item *item, double * pt, double * w)
+{
+  GnomeCanvasPoints poly;
+  double polypt[8];
+
+  poly.coords = polypt;
+  poly.num_points = 4;
+  poly.ref_count = 1;
+  gnome_canvas_get_butt_points(pt[0], pt[1], pt[2], pt[3], w[1], 0,
+    polypt+0, polypt+1, polypt+2, polypt+3);
+  gnome_canvas_get_butt_points(pt[2], pt[3], pt[0], pt[1], w[0], 0,
+    polypt+4, polypt+5, polypt+6, polypt+7);
+  
+  gnome_canvas_item_new((GnomeCanvasGroup *) item->canvas_item,
+     gnome_canvas_polygon_get_type(), "points", &poly,
+     "fill-color-rgba", item->brush.color_rgba, NULL);
+
+}
+
+
 void make_canvas_item_one(GnomeCanvasGroup *group, struct Item *item)
 {
   PangoFontDescription *font_desc;
@@ -642,16 +671,13 @@ void make_canvas_item_one(GnomeCanvasGroup *group, struct Item *item)
     else {
       item->canvas_item = gnome_canvas_item_new(group,
             gnome_canvas_group_get_type(), NULL);
-      points.num_points = 2;
-      points.ref_count = 1;
+
       for (j = 0; j < item->path->num_points-1; j++) {
-        points.coords = item->path->coords+2*j;
-        gnome_canvas_item_new((GnomeCanvasGroup *) item->canvas_item,
-              gnome_canvas_line_get_type(), "points", &points, 
-              "cap-style", GDK_CAP_ROUND, "join-style", GDK_JOIN_ROUND, 
-              "fill-color-rgba", item->brush.color_rgba,
-              "width-units", item->widths[j], NULL);
+        make_canvas_stroke_disc(item, item->path->coords+2*j, item->widths+j);
+        make_canvas_stroke_segment(item, item->path->coords+2*j, item->widths+j);
       }
+      make_canvas_stroke_disc(item, item->path->coords+2*(item->path->num_points-1),
+                                    item->widths+item->path->num_points-1);
     }
   }
   if (item->type == ITEM_TEXT) {
@@ -2012,7 +2038,7 @@ void resize_journal_items_by(GList *itemlist, double scaling_x, double scaling_y
         pt[1] = pt[1]*scaling_y + offset_y;
       }
       if (item->brush.variable_width)
-        for (i=0, wid=item->widths; i<item->path->num_points-1; i++, wid++)
+        for (i=0, wid=item->widths; i<item->path->num_points; i++, wid++)
           *wid = *wid * mean_scaling;
 
       item->bbox.left = item->bbox.left*scaling_x + offset_x;

--- a/src/xo-misc.h
+++ b/src/xo-misc.h
@@ -48,6 +48,8 @@ void update_item_bbox(struct Item *item);
 void make_page_clipbox(struct Page *pg);
 void make_canvas_items(void);
 void make_canvas_item_one(GnomeCanvasGroup *group, struct Item *item);
+void make_canvas_stroke_disc(struct Item *item, double * pt, double * w);
+void make_canvas_stroke_segment(struct Item *item, double * pt, double * w);
 void update_canvas_bg(struct Page *pg);
 gboolean is_visible(struct Page *pg);
 void rescale_bg_pixmaps(void);

--- a/src/xo-misc.h
+++ b/src/xo-misc.h
@@ -49,7 +49,7 @@ void make_page_clipbox(struct Page *pg);
 void make_canvas_items(void);
 void make_canvas_item_one(GnomeCanvasGroup *group, struct Item *item);
 void make_canvas_stroke_disc(struct Item *item, double * pt, double * w);
-void make_canvas_stroke_segment(struct Item *item, double * pt, double * w);
+void make_canvas_stroke_trapeze(struct Item *item, double * pt, double * w);
 void update_canvas_bg(struct Page *pg);
 gboolean is_visible(struct Page *pg);
 void rescale_bg_pixmaps(void);

--- a/src/xo-paint.c
+++ b/src/xo-paint.c
@@ -305,7 +305,7 @@ void continue_stroke(GdkEvent *event)
          "fill-color-rgba", ui.cur_item->brush.color_rgba,
          "width-units", (ui.cur_widths[ui.cur_path.num_points-2] + ui.cur_widths[ui.cur_path.num_points-1]) / 2, NULL);      
     } else {
-      make_canvas_stroke_segment(ui.cur_item, pt, ui.cur_widths+ui.cur_path.num_points-2);
+      make_canvas_stroke_trapeze(ui.cur_item, pt, ui.cur_widths+ui.cur_path.num_points-2);
       make_canvas_stroke_disc(ui.cur_item, pt + 2, ui.cur_widths+ui.cur_path.num_points-1);
    }
   } else {

--- a/src/xo-paint.c
+++ b/src/xo-paint.c
@@ -293,8 +293,21 @@ void continue_stroke(GdkEvent *event)
      into an internal structure */
 
   if (ui.cur_item->brush.variable_width) {
-    make_canvas_stroke_segment(ui.cur_item, pt, ui.cur_widths+ui.cur_path.num_points-2);
-    make_canvas_stroke_disc(ui.cur_item, pt + 2, ui.cur_widths+ui.cur_path.num_points-1);
+    if (ui.cur_widths[ui.cur_path.num_points-1] < ui.cur_widths[ui.cur_path.num_points-2] * LINE_WIDTH_PRECISION &&
+        ui.cur_widths[ui.cur_path.num_points-2] < ui.cur_widths[ui.cur_path.num_points-1] * LINE_WIDTH_PRECISION) {
+      GnomeCanvasPoints seg;
+      seg.coords = pt; 
+      seg.num_points = 2;
+      seg.ref_count = 1;
+      gnome_canvas_item_new((GnomeCanvasGroup *)ui.cur_item->canvas_item,
+         gnome_canvas_line_get_type(), "points", &seg,
+         "cap-style", GDK_CAP_ROUND, "join-style", GDK_JOIN_ROUND,
+         "fill-color-rgba", ui.cur_item->brush.color_rgba,
+         "width-units", (ui.cur_widths[ui.cur_path.num_points-2] + ui.cur_widths[ui.cur_path.num_points-1]) / 2, NULL);      
+    } else {
+      make_canvas_stroke_segment(ui.cur_item, pt, ui.cur_widths+ui.cur_path.num_points-2);
+      make_canvas_stroke_disc(ui.cur_item, pt + 2, ui.cur_widths+ui.cur_path.num_points-1);
+   }
   } else {
     GnomeCanvasPoints seg;
     seg.coords = pt; 

--- a/src/xo-print.c
+++ b/src/xo-print.c
@@ -1682,13 +1682,24 @@ void print_page_to_cairo(cairo_t *cr, struct Page *pg, gdouble width, gdouble he
           cairo_stroke(cr);
           old_thickness = item->brush.thickness;
         } else {
-          for (i=0; i<item->path->num_points-1; i++, pt+=2) {
-            cairo_move_to(cr, pt[0], pt[1]);
-            cairo_set_line_width(cr, item->widths[i]);
-            cairo_line_to(cr, pt[2], pt[3]);
-            cairo_stroke(cr);
+          for (i=0; i<item->path->num_points; i++, pt+=2) {
+            double wh = item->widths[i] / 2;
+            cairo_move_to(cr, pt[0] + wh, pt[1]);
+            cairo_arc(cr, pt[0], pt[1], wh, 0, 360);
+                        
+            if (i < item->path->num_points-1) {
+              double polypt[8];
+              gnome_canvas_get_butt_points(pt[0], pt[1], pt[2], pt[3], item->widths[i+1], 0,
+                polypt+0, polypt+1, polypt+2, polypt+3);
+              gnome_canvas_get_butt_points(pt[2], pt[3], pt[0], pt[1], item->widths[i], 0,
+                polypt+4, polypt+5, polypt+6, polypt+7);
+              cairo_move_to(cr, polypt[0], polypt[1]);
+              cairo_line_to(cr, polypt[2], polypt[3]);
+              cairo_line_to(cr, polypt[4], polypt[5]);
+              cairo_line_to(cr, polypt[6], polypt[7]);
+            }
           }
-          old_thickness = 0.0;
+          cairo_fill(cr);
         }
       }
       if (item->type == ITEM_TEXT) {

--- a/src/xo-print.c
+++ b/src/xo-print.c
@@ -24,6 +24,7 @@
 #include <libgnomecanvas/libgnomecanvas.h>
 #include <zlib.h>
 #include <string.h>
+#include <math.h>
 #include <locale.h>
 #include <pango/pango.h>
 #include <pango/pangofc-font.h>
@@ -1682,24 +1683,43 @@ void print_page_to_cairo(cairo_t *cr, struct Page *pg, gdouble width, gdouble he
           cairo_stroke(cr);
           old_thickness = item->brush.thickness;
         } else {
-          for (i=0; i<item->path->num_points; i++, pt+=2) {
-            double wh = item->widths[i] / 2;
-            cairo_move_to(cr, pt[0] + wh, pt[1]);
-            cairo_arc(cr, pt[0], pt[1], wh, 0, 360);
-                        
-            if (i < item->path->num_points-1) {
-              double polypt[8];
-              gnome_canvas_get_butt_points(pt[0], pt[1], pt[2], pt[3], item->widths[i+1], 0,
-                polypt+0, polypt+1, polypt+2, polypt+3);
-              gnome_canvas_get_butt_points(pt[2], pt[3], pt[0], pt[1], item->widths[i], 0,
-                polypt+4, polypt+5, polypt+6, polypt+7);
-              cairo_move_to(cr, polypt[0], polypt[1]);
-              cairo_line_to(cr, polypt[2], polypt[3]);
-              cairo_line_to(cr, polypt[4], polypt[5]);
-              cairo_line_to(cr, polypt[6], polypt[7]);
+
+          double wmin, wmax;
+          int j, j0;
+          j0 = 0;
+    
+          while (j0 < item->path->num_points - 1) {
+            
+            wmin = wmax = item->widths[j0];
+            
+            j = j0 + 1;
+            while (j < item->path->num_points &&
+                   item->widths[j] < wmin * LINE_WIDTH_PRECISION &&
+                   item->widths[j] * LINE_WIDTH_PRECISION > wmax) {
+              if (item->widths[j] < wmin) wmin = item->widths[j];
+              if (item->widths[j] > wmax) wmax = item->widths[j];
+              j++;
+            }
+            
+            if (j0 < j - 1) {
+              /* draw from j0 to j-1 */
+              cairo_set_line_width(cr, (wmin + wmax) / 2);
+              cairo_move_to(cr, pt[2*j0], pt[2*j0+1]);
+              for (i = j0 + 1; i <= j - 1; i++) {
+                cairo_line_to(cr, pt[2*i], pt[2*i+1]);
+              }
+              cairo_stroke(cr);
+              j0 = j - 1;
+            } else { /* j == j0+1; draw trapeze from j0 to j... including the discs */
+              double angle = atan2(pt[2*j+1]-pt[2*j0+1], pt[2*j]-pt[2*j0]);
+              /* The following it not perfect if the two line widths differ a lot... */
+              cairo_arc(cr, pt[2*j0], pt[2*j0 + 1], item->widths[j0]/2, angle + M_PI / 2, angle - M_PI / 2);
+              cairo_arc(cr, pt[2*j], pt[2*j + 1], item->widths[j]/2, angle - M_PI / 2, angle + M_PI / 2);
+              cairo_fill(cr);
+              j0 = j;
             }
           }
-          cairo_fill(cr);
+
         }
       }
       if (item->type == ITEM_TEXT) {

--- a/src/xo-print.c
+++ b/src/xo-print.c
@@ -1683,15 +1683,12 @@ void print_page_to_cairo(cairo_t *cr, struct Page *pg, gdouble width, gdouble he
           cairo_stroke(cr);
           old_thickness = item->brush.thickness;
         } else {
-
           double wmin, wmax;
           int j, j0;
           j0 = 0;
-    
+
           while (j0 < item->path->num_points - 1) {
-            
             wmin = wmax = item->widths[j0];
-            
             j = j0 + 1;
             while (j < item->path->num_points &&
                    item->widths[j] < wmin * LINE_WIDTH_PRECISION &&
@@ -1700,7 +1697,7 @@ void print_page_to_cairo(cairo_t *cr, struct Page *pg, gdouble width, gdouble he
               if (item->widths[j] > wmax) wmax = item->widths[j];
               j++;
             }
-            
+
             if (j0 < j - 1) {
               /* draw from j0 to j-1 */
               cairo_set_line_width(cr, (wmin + wmax) / 2);
@@ -1719,7 +1716,7 @@ void print_page_to_cairo(cairo_t *cr, struct Page *pg, gdouble width, gdouble he
               j0 = j;
             }
           }
-
+          old_thickness = 0.0;
         }
       }
       if (item->type == ITEM_TEXT) {

--- a/src/xournal.h
+++ b/src/xournal.h
@@ -63,6 +63,7 @@
 #define MIN_ZOOM 0.2
 #define RESIZE_MARGIN 6.0
 #define MAX_SAFE_RENDER_DPI 720 // max dpi at which PDF bg's get rendered
+#define LINE_WIDTH_PRECISION 1.2 // factor by which a line width can be drawn wrongly
 
 #define VBOX_MAIN_NITEMS 5 // number of interface items in vboxMain
 


### PR DESCRIPTION
This patch makes variable thickness lines more beautiful, by making thickness changing continuously. In addition, there is some optimization on how lines are drawn, since otherwise, this patch would have made xournal unusably slow on big documents. (In contrast, with the optimization, xournal becomes a lot faster with this patch).

**Details about improved line widths:**
- About motivation/"history": I used to be (and still am) very happy with how lines look like in xournal on a lenovo thinkpad. On a microsoft surface pro, however, the line endings didn't look that good: They are thicker than they should be. This makes hand writing noticeably more ugly (at least for my taste). I still don't really know why they looked different; maybe the thinkpad sends pressure data more often? Anyway, using inkscape, pressure sensitive lines do look good even on the surface, so I wanted to also improve xournal accordingly. It turned out that it suffices to take into account the pressure at the very beginning of a line stroke (which xournal didn't). However, since that pressure is often nearly 0 (compared to the second pressure), it became necessary to draw trapzoids, to make this look good.
- item->linewidths used to contain one width for each segment; now it contains one width for each vertex, so one more than before. (Since the width of a segment was taken from the pressure at the end of the segment, the additional width is at the beginning of a stroke.)
- Each segment is drawn as a trapezoid (by make_canvas_stroke_segment); moreover, to connect those trapezes properly, a disc is drawn at every point (by make_canvas_stroke_disc)
- The same is done for printing (and creating pdf files), though by separate code (and only in the cairo version of printing), with a small difference, though: In pdf files, one can create shapes consisting of trapezoids with attached half-discs at their ends, thus making separate discs unnecessary.
- To keep backwards compatibility of xoj files, the additional width at the beginning of a stroke is stored by adding an additional dummy point at the beginning of each stroke, with the same coordinates as the first real point.

**Details about optimizations:**

Not first: For variable-width lines, each segment is drawn separately (i.e., a separate canvas object is created), whereas fixed width lines consist of a single canvas object; apparently, this makes a big performance difference. Drawing trapezoids (moreover with additional discs) is even a lot slower. All this is optimized at the cost of being slightly imprecise:
- If the widths at the beginning and at the end of a segment differ by a factor of at most 1.2, then a line of the average width is drawn instead of a trapezoid. In this way, 90% of the segments get drawn in the old way, making xournal almost as fast as it had been before.
- If several consecutive segments have widths differing by at most 1.2, then all of them are drawn as one single canvas item (with average width). This reduces the number of canvas objects by a factor 4 or so, making xournal a lot faster than it was before.
- The same kind of optimizations have been made for creation of pdf files, making the pdf files smaller and faster to load, compared to the unoptimized but beautified version; however, they don't seem to become noticeably better than before the patch. (Apparently, here the number of objects doesn't matter.)
- The 1.2 above is a constant called LINE_WIDTH_PRECISION; I did not yet fine-tune it. One could probably make it a bit bigger without the imprecision becoming noticeable and in this way make xournal even faster.
